### PR TITLE
newrelic-infra install on redhat issue fix proposal

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@ newrelic:
   appname: "New Relic PHP App"
   php_conf_dir: /etc/php/5.6/mods-available
   php_command_prefix: php
+  install_newrelic_infra: True

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,3 +12,11 @@
     name: newrelic-infra
     state: restarted
     enabled: yes
+  when: newrelic.install_newrelic_infra == True
+
+- name: restart php-fpm
+  become: yes
+  service:
+    name: php-fpm
+    state: restarted
+    enabled: yes

--- a/tasks/post-setup.yml
+++ b/tasks/post-setup.yml
@@ -19,6 +19,8 @@
     line: "license_key: {{ newrelic.license_key }}"
     create: yes
   no_log: True
+  when:
+    newrelic.install_newrelic_infra == True
 
 - include_tasks: setup-PHP-Debian.yml
   when: ansible_os_family == 'Debian' and php_present|success

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -20,12 +20,18 @@
     - path: https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
       id: ""
 
-- name: Install NewRelic with apt
+- name: Install NewRelic Sysmond with apt
   become: yes
   apt:
-    name: "{{ item }}"
+    name: newrelic-sysmond
     state: present
     force: yes
-  with_items:
-    - "newrelic-sysmond"
-    - "newrelic-infra"
+
+- name: Install NewRelic Infra with apt
+  become: yes
+  apt:
+    name: newrelic-infra
+    state: present
+    force: yes
+  when:
+    newrelic.install_newrelic_infra == True

--- a/tasks/setup-PHP.yml
+++ b/tasks/setup-PHP.yml
@@ -9,3 +9,6 @@
     appname: "{{ newrelic.appname }}"
     license: "{{ newrelic.license_key }}"
   no_log: True
+  notify:
+    - restart php-fpm
+  when: php_present|success

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -5,7 +5,7 @@
     name: http://download.newrelic.com/pub/newrelic/el5/i386/newrelic-repo-5-3.noarch.rpm
     state: present
 
-- name: Install New Relic with yum
+- name: Install NewRelic Sysmond with yum
   become: yes
   yum:
     name: newrelic-sysmond


### PR DESCRIPTION
Hi. I propose this fix. 
It's bring new variable "install_newrelic_infra" default  set to True. 
And check's it when installing on RedHat/Centos
Also minor fix with restarting php-fpm after changes